### PR TITLE
SV2-2888-gpu-jobs

### DIFF
--- a/zerog/mgmt/manager.py
+++ b/zerog/mgmt/manager.py
@@ -5,11 +5,13 @@ from .utils import parse_worker_id
 
 
 class WorkerManager(object):
-    def __init__(self, queueHost, queuePort):
+    def __init__(self, queueHost, queuePort, **kwargs):
         self.queueHost = queueHost
         self.queuePort = queuePort
 
-        self.queue = self.get_queue(zerog.UPDATES_CHANNEL_NAME)
+        self.queue = self.get_queue(
+            zerog.UPDATES_CHANNEL_NAME + kwargs.get("updatesPostfix", "")
+        )
         self.updatesChannel = MgmtChannel(self.queue)
 
         self.jobRuns = {}

--- a/zerog/server.py
+++ b/zerog/server.py
@@ -79,8 +79,13 @@ class Server(tornado.web.Application):
 
         self.datastore = makeDatastore()
         self.jobQueue = makeQueue("{0}_jobs".format(self.name))
+
+        # ugly hack to add extra zerog management channels on the same
+        # queue server
         self.updatesChannel = MgmtChannel(
-            makeQueue(zerog.UPDATES_CHANNEL_NAME)
+            makeQueue(
+                zerog.UPDATES_CHANNEL_NAME + kwargs.get("updatesPostfix", "")
+            )
         )
         self.ctrlChannel = MgmtChannel(makeQueue(self.workerId))
 


### PR DESCRIPTION
support the addition of a "postfix" that can be added to the name of the `zerog.mgmt` updates channel. This makes it possible to manage multiple groups of `zerog` services that share the same queue server.

already tested in the `lab-exp` environment.